### PR TITLE
Fixed Mobile menu button not showing on 768px width screen i.e. Ipad Mini

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -8,7 +8,7 @@
             {{ partial "menu.html" (dict "menuID" "main" "page" .) }}
         </div>
     </nav>
-    <div class="absolute top-8 right-5 flex items-center sm:hidden">
+    <div class="absolute top-8 right-5 flex items-center lg:hidden">
         <!-- Mobile menu button-->
         <button @click="openMenu = !openMenu" type="button"
             class="relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-800 hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"


### PR DESCRIPTION
Screen width 768 does not have a menu.

Fixed by updating `sm:hidden` to `lg:hidden`

Before:
<img width="585" alt="Screenshot 2024-09-14 at 6 01 51 AM" src="https://github.com/user-attachments/assets/a243c6a8-78f8-4e54-90a9-a337a2b38602">

After:
<img width="582" alt="Screenshot 2024-09-14 at 6 06 11 AM" src="https://github.com/user-attachments/assets/4459c4de-9841-4e19-950b-2496be819be6">

Aligned this when the navbar changes to horizontal layout

```
    <nav class="flex flex-1 flex-col lg:flex-row items-center justify-between">
        <a href="/">
            <img src="/image/logo.webp" alt="site logo"
                class="w-16 h-16 my-5 p-1 bg-gray-100 rounded-full cursor-pointer hover:scale-110" />
        </a>
        <div class="hidden lg:block" :class="{'hidden': !openMenu}">
            {{ partial "menu.html" (dict "menuID" "main" "page" .) }}
        </div>
    </nav>
```
<img width="525" alt="Screenshot 2024-09-14 at 6 07 14 AM" src="https://github.com/user-attachments/assets/bfabc1b7-fe94-441a-a0a0-fd273c54edc0">


