### PR TITLE
Fix typo

### DIFF
--- a/layouts/partials/imagextractor.html
+++ b/layouts/partials/imagextractor.html
@@ -19,7 +19,7 @@
 {{ end }}
 {{ end }}
 
-<!-- Weather have featured image in front matter -->
+<!-- Whether has featured image in front matter -->
 {{ with $page.Params.featuredImage }}
 {{ $image := . | absURL }}
 {{ end }}


### PR DESCRIPTION
**Summary**
I just noticed a small typo in the `imagextractor.html`

**Fixes**
Fixed the typo 😄 