### PR TITLE
Update imagextractor.html

### DIFF
--- a/layouts/partials/imagextractor.html
+++ b/layouts/partials/imagextractor.html
@@ -28,9 +28,9 @@
 <!-- Local image eg: ./abc.jpeg or /abc.png -->
 {{ $regex := `img[\s]+alt="([^"]+)"[\s]+src="([^"]+)"` }}
 {{ $matches := findRESubmatch $regex $page.Content }}
-{{ range $matches }}
-{{ $image = index . 2 | safeURL }}
-{{ $alt = index . 1 | safeHTML }}
+{{ with index $matches 0 }}
+  {{ $image = index . 2 | safeURL }}
+  {{ $alt = index . 1 | safeHTML }}
 {{ end }}
 {{ end }}
 
@@ -38,9 +38,9 @@
 <!-- Local image eg: ./abc.jpeg or /abc.png -->
 {{ $regex := `img[\s]+src="([^"]+)"[\s]+alt="([^"]+)"` }}
 {{ $matches := findRESubmatch $regex $page.Content }}
-{{ range $matches }}
-{{ $image = index . 1 | safeURL }}
-{{ $alt = index . 2 | safeHTML }}
+{{ with index $matches 0 }}
+  {{ $image = index . 1 | safeURL }}
+  {{ $alt = index . 2 | safeHTML }}
 {{ end }}
 {{ end }}
 


### PR DESCRIPTION
**Summary**
I have noticed, when an image is not specified for a preview image, the last image on the blog is chosen as the preview image. 

I thought it would make sense to use the first image of the blog as the preview image, rather than the last image in the preview file. 

**Additions**
Changed the `imagextractor.html` to only use the first image of the markdown file if it exists.

